### PR TITLE
Remove unnecessary & unsafe floating point operations. Though precision ...

### DIFF
--- a/lib/coinbase/client.rb
+++ b/lib/coinbase/client.rb
@@ -41,7 +41,7 @@ module Coinbase
       options[:button]                        ||= {}
       options[:button][:name]                 ||= name
       price = price.to_money unless price.is_a?(Money)
-      options[:button][:price_string]         ||= price.to_f.to_s
+      options[:button][:price_string]         ||= price.to_s
       options[:button][:price_currency_iso]   ||= price.currency.iso_code
       options[:button][:description]          ||= description
       options[:button][:custom]               ||= custom
@@ -69,7 +69,7 @@ module Coinbase
       options[:transaction]                         ||= {}
       options[:transaction][:to]                    ||= to
       amount = amount.to_money unless amount.is_a?(Money)
-      options[:transaction][:amount_string]         ||= amount.to_f.to_s
+      options[:transaction][:amount_string]         ||= amount.to_s
       options[:transaction][:amount_currency_iso]   ||= amount.currency.iso_code
       options[:transaction][:notes]                 ||= notes
       r = post '/transactions/send_money', options
@@ -83,7 +83,7 @@ module Coinbase
       options[:transaction]                         ||= {}
       options[:transaction][:from]                  ||= from
       amount = amount.to_money unless amount.is_a?(Money)
-      options[:transaction][:amount_string]         ||= amount.to_f.to_s
+      options[:transaction][:amount_string]         ||= amount.to_s
       options[:transaction][:amount_currency_iso]   ||= amount.currency.iso_code
       options[:transaction][:notes]                 ||= notes
       r = post '/transactions/request_money', options


### PR DESCRIPTION
...issues shouldn't happen with RubyMoney/Money (see the way to_d is implemented at https://github.com/RubyMoney/money/blob/master/lib/money/money.rb), it's advisable not to let currency touch floats if possible, especially since the rest of the Money logic operates on BigDecimal.
