### PR TITLE
Money gem deprecation warning tweaks

### DIFF
--- a/lib/coinbase/client.rb
+++ b/lib/coinbase/client.rb
@@ -23,8 +23,8 @@ module Coinbase
     # Account
 
     def balance options={}
-      h = get '/account/balance', options
-      h['amount'].to_money(h['currency'])
+      r = get '/account/balance', options
+      Money.new_with_amount(r['amount'].to_f, r['currency'])     
     end
 
     def receive_address options={}
@@ -117,12 +117,12 @@ module Coinbase
 
     def buy_price qty=1
       r = get '/prices/buy', {qty: qty}
-      r['amount'].to_money(r['currency'])
+      Money.new_with_amount(r['amount'].to_f, r['currency']) 
     end
 
     def sell_price qty=1
       r = get '/prices/sell', {qty: qty}
-      r['amount'].to_money(r['currency'])
+      Money.new_with_amount(r['amount'].to_f, r['currency']) 
     end
 
     # Buys

--- a/lib/coinbase/version.rb
+++ b/lib/coinbase/version.rb
@@ -1,3 +1,3 @@
 module Coinbase
-  VERSION = "1.2.4"
+  VERSION = "1.2.5"
 end


### PR DESCRIPTION
The calls to convert balance, buy, and sell prices to Money objects were tweaked to avoid generating deprecation warnings from the Money gem by using 'to_money'. There are plenty more warnings, but these are the first I hit playing with the coinbase gem.
![src__bash__11829](https://f.cloud.github.com/assets/41010/1501310/8c3970d6-4889-11e3-9d26-1bea4f97e42f.png)
![src__bash__11829-2](https://f.cloud.github.com/assets/41010/1501311/8ebc67a0-4889-11e3-92e9-9c78bf2ce220.png)
