### PR TITLE
Added spot price functionality and clarified price descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ Transactions will always have an `id` attribute which is the primary way to iden
 
 ### Check bitcoin prices
 
-Check the buy or sell price by passing a `quantity` of bitcoin that you'd like to buy or sell.  This price includes Coinbase's fee of 1% and the bank transfer fee of $0.15.
+Check the `buy_price` or `sell price` by passing a `quantity` of bitcoin that you'd like to buy or sell.  This price includes Coinbase's fee of 1% and the bank transfer fee of $0.15. You can check the current `spot_price` as well, but this method cannot be passed a quantity.
+
+The `buy_price` and `sell_price` per Bitcoin will increase and decrease respectively as `quantity` increases. This per unit price differential is driven by the BTC [market depth](http://en.wikipedia.org/wiki/Market_depth).
 
 ```ruby
 coinbase.buy_price(1).format
@@ -153,8 +155,14 @@ coinbase.buy_price(30).format
 ```ruby
 coinbase.sell_price(1).format
 => "$17.93"
-coinbase.buy_price(30).format
+coinbase.sell_price(30).format
 => "$534.60"
+```
+
+
+```ruby
+coinbase.spot_price.format
+=> "$17.94"
 ```
 
 ### Buy or Sell bitcoin

--- a/lib/coinbase/client.rb
+++ b/lib/coinbase/client.rb
@@ -139,6 +139,11 @@ module Coinbase
       r['amount'].to_money(r['currency'])
     end
 
+    def spot_price
+      r = get '/prices/spot_rate'
+      r['amount'].to_money(r['currency'])
+    end
+
     # Buys
 
     def buy! qty

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -134,7 +134,7 @@ describe Coinbase::Client do
 
   # Prices
 
-  it "should let you get buy and sell prices" do
+  it "should let you get buy, sell and spot prices" do
     response = {"amount"=>"13.84", "currency"=>"USD"}
     fake :get, "/prices/buy", response
     r = @c.buy_price 1
@@ -142,6 +142,10 @@ describe Coinbase::Client do
 
     fake :get, "/prices/sell", response
     r = @c.sell_price 1
+    r.to_f.should == 13.84
+
+    fake :get, "/prices/spot_rate", response
+    r = @c.spot_price
     r.to_f.should == 13.84
   end
 


### PR DESCRIPTION
Added a `spot_price` method to enable an easy GET request to '/api/v1/prices/spot_rate.' Mirroring the API, the `spot_price` method cannot take a `quantity` argument.

I also added some minor clarifications and examples to the **_Check bitcoin prices_** section of the README. The existing description for the `sell_price` method shows a `buy_price` example. 
