### PR TITLE
Add spot_price method to check BTC spot rate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Transactions will always have an `id` attribute which is the primary way to iden
 
 ### Check bitcoin prices
 
-Check the buy or sell price by passing a `quantity` of bitcoin that you'd like to buy or sell.  This price includes Coinbase's fee of 1% and the bank transfer fee of $0.15.
+Check the buy, sell, or spot price by passing a `quantity` of bitcoin that you'd like to buy or sell.  This price includes Coinbase's fee of 1% and the bank transfer fee of $0.15.
 
 ```ruby
 coinbase.buy_price(1).format
@@ -141,7 +141,14 @@ coinbase.buy_price(30).format
 ```ruby
 coinbase.sell_price(1).format
 => "$17.93"
-coinbase.buy_price(30).format
+coinbase.sell_price(30).format
+=> "$534.60"
+```
+
+```ruby
+coinbase.spot_price(1).format
+=> "$17.93"
+coinbase.spot_price(30).format
 => "$534.60"
 ```
 

--- a/lib/coinbase/client.rb
+++ b/lib/coinbase/client.rb
@@ -138,6 +138,11 @@ module Coinbase
       r['amount'].to_money(r['currency'])
     end
 
+    def spot_price qty=1
+      r = get '/prices/spot_rate', {qty: qty}
+      r['amount'].to_money(r['currency'])
+    end
+
     # Buys
 
     def buy! qty

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -134,13 +134,17 @@ describe Coinbase::Client do
 
   # Prices
 
-  it "should let you get buy and sell prices" do
+  it "should let you get buy, sell, and spot prices" do
     response = {"amount"=>"13.84", "currency"=>"USD"}
     fake :get, "/prices/buy", response
     r = @c.buy_price 1
     r.to_f.should == 13.84
 
     fake :get, "/prices/sell", response
+    r = @c.sell_price 1
+    r.to_f.should == 13.84
+
+    fake :get, "/prices/spot_rate", response
     r = @c.sell_price 1
     r.to_f.should == 13.84
   end


### PR DESCRIPTION
The API provides an endpoint to check the spot rate of BTC. The client
library should provide a method to access this endpoint.

This commit also includes specs and updates to the README.md.
