### PR TITLE
allow options for buy method

### DIFF
--- a/lib/coinbase/client.rb
+++ b/lib/coinbase/client.rb
@@ -175,8 +175,8 @@ module Coinbase
 
     # Buys
 
-    def buy! qty
-      r = post '/buys', {qty: qty}
+    def buy! qty, options = {}
+      r = post '/buys', options.merge({qty: qty})
       r = convert_money_objects(r)
       r.transfer.payout_date = Time.parse(r.transfer.payout_date) rescue nil
       r


### PR DESCRIPTION
account_id 
Specify which account is used for crediting bought amount. The default is your primary account.
Value: Must be String

agree_btc_amount_varies 
Whether or not you would still like to buy if you have to wait for your money to arrive to lock in a price.
Value: Must be Boolean

payment_method_id 
The ID of the payment method that should be used for the buy. Payment methods can be listed using the /payment_methods API call.
Value: Must be String
