### PR TITLE
Correctly log response.code

### DIFF
--- a/lib/coinbase/oauth_client.rb
+++ b/lib/coinbase/oauth_client.rb
@@ -58,7 +58,7 @@ module Coinbase
       when 504
         raise TimeoutError, "Gateway timeout, please try again later"
       when 500..600
-        raise ServerError, "Server error: (#{r.code})"
+        raise ServerError, "Server error: (#{response.code})"
       when 401
         raise UnauthorizedError
       when 404


### PR DESCRIPTION
Was getting errors `NameError: undefined local variable or method 'r'`, this should fix that since the method is using the `response` variable rather than `r`
