### PR TITLE
Update gems dependencies

### DIFF
--- a/coinbase.gemspec
+++ b/coinbase.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |gem|
   # Gems that must be intalled for sift to work
   gem.add_dependency "httparty", ">= 0.8.3"
   gem.add_dependency "multi_json", ">= 1.3.4"
-  gem.add_dependency "money", "~> 6.0"
-  gem.add_dependency "monetize", "~> 0.3.0"
+  gem.add_dependency "money", "~> 6.5"
+  gem.add_dependency "monetize", "~> 1.1"
   gem.add_dependency "hashie", ">= 1.2.0"
   gem.add_dependency "oauth2", "~> 1.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
 require 'simplecov'
 SimpleCov.start
+
+require "money"
+Money.use_i18n = false


### PR DESCRIPTION
I'm currently running Rails 4.2, and coinbase-ruby's depends on an old version of monetize/money (which in turn referenced even older versions of the i18n gems) and I was getting pretty nasty conflicts. Updated the gems and then updated the tests, all seems fine.