### PR TITLE
Commit Transfer

### DIFF
--- a/lib/coinbase/client.rb
+++ b/lib/coinbase/client.rb
@@ -10,7 +10,7 @@ module Coinbase
   class Client
     include HTTParty
 
-    BASE_URI = 'https://coinbase.com/api/v1'
+    BASE_URI = 'https://api.coinbase.com/v1'
 
     def initialize(api_key='', api_secret='', options={})
       @api_key = api_key
@@ -162,14 +162,20 @@ module Coinbase
 
     # Buys
 
-    def buy! qty
-      post '/buys', {qty: qty}
+    def buy! qty, options = {}
+      post '/buys', options.merge({qty: qty})
     end
 
     # Sells
 
     def sell! qty
       post '/sells', {qty: qty}
+    end
+
+    # Commit transfer (pending buy or sell)
+
+    def commit_transfer! id
+      post "/transfers/#{id}/commit"
     end
 
     # Transfers

--- a/lib/coinbase/version.rb
+++ b/lib/coinbase/version.rb
@@ -1,3 +1,3 @@
 module Coinbase
-  VERSION = "2.1.1"
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
Added this at the suggestion of Jori and John. This allows users to turn their pending buys/sells into completed ones by posting to `/transfers/:id/commit`

Updated the version based on a dependency error I got from `omniauth-ruby` asking for a `coinbase` version of 3 or greater