### PR TITLE
Added generic support for 2FA handling to client.

### DIFF
--- a/lib/coinbase/oauth_client.rb
+++ b/lib/coinbase/oauth_client.rb
@@ -28,7 +28,8 @@ module Coinbase
         :ssl           => {
                             :verify => true,
                             :cert_store => ::Coinbase::Client.whitelisted_cert_store
-                          }
+                          },
+        :raise_errors  => false
       }
       @oauth_client = OAuth2::Client.new(client_id, client_secret, client_opts)
       token_hash = user_credentials.dup
@@ -49,14 +50,11 @@ module Coinbase
       if [:get, :delete].include? verb
         request_options = {params: options}
       else
-        request_options = {headers: {"Content-Type" => "application/json"}, body: options.to_json}
+        request_options = {headers: build_headers({"Content-Type" => "application/json"}, options), body: options.to_json}
       end
       response = oauth_token.request(verb, path, request_options)
 
-      hash = Hashie::Mash.new(JSON.parse(response.body))
-      raise Error.new(hash.error) if hash.error
-      raise Error.new(hash.errors.join(", ")) if hash.errors
-      hash
+      handle_response(response)
     end
 
     def refresh!


### PR DESCRIPTION
The current client doesnt understand the 402 2FA challenge response. You can not handle 2FA something like this:

```ruby
  begin
     client.send_money('test@test.com', '1', 'your message', token_2fa: params[:token_2fa])
  rescue Coinbase::Client::TwoFactorAuthError
    # Show 2FA dialog to user
  end
 ```

So the first time you won't have a 2fa_token so you will trigger the TwoFactorAuthError, when that triggers you can show the dialog. After the user enters the code, just resubmit the request passing token_2fa option to the send_money call. 
