### PR TITLE
Support for showing an order and Coinbase::Client sandbox

### DIFF
--- a/lib/coinbase/client.rb
+++ b/lib/coinbase/client.rb
@@ -24,6 +24,7 @@ module Coinbase
       else
         @base_uri = BASE_URI
       end
+      options.delete(:sandbox)
       options[:base_uri] = @base_uri
       options[:format]   ||= :json
 

--- a/lib/coinbase/client.rb
+++ b/lib/coinbase/client.rb
@@ -139,6 +139,12 @@ module Coinbase
       put "/transactions/#{transaction_id}/complete_request"
     end
 
+    # Orders
+
+    def order order_id, account_id = ''
+      get "/orders/#{order_id}/#{account_id}"
+    end
+
     # Users
 
     def current_user

--- a/lib/coinbase/client.rb
+++ b/lib/coinbase/client.rb
@@ -11,15 +11,22 @@ module Coinbase
     include HTTParty
 
     BASE_URI = 'https://api.coinbase.com/v1'
+    SANDBOX_BASE_URI = 'https://api.sandbox.coinbase.com/v1'
 
     def initialize(api_key='', api_secret='', options={})
       @api_key = api_key
       @api_secret = api_secret
 
-      # defaults
-      options[:base_uri] ||= BASE_URI
-      @base_uri = options[:base_uri]
+      if options[:base_uri]
+        @base_uri = options[:base_uri]
+      elsif options.delete(:sandbox)
+        @base_uri = SANDBOX_BASE_URI
+      else
+        @base_uri = BASE_URI
+      end
+      options[:base_uri] = @base_uri
       options[:format]   ||= :json
+
       options.each do |k,v|
         self.class.send k, v
       end

--- a/lib/coinbase/oauth_client.rb
+++ b/lib/coinbase/oauth_client.rb
@@ -23,9 +23,10 @@ module Coinbase
     # Use the credentials method when finished with the client to retrieve up-to-date credentials
     def initialize(client_id, client_secret, user_credentials, options={})
       if options[:sandbox]
+        options[:base_uri] = SANDBOX_BASE_URI
         options[:site] = 'https://sandbox.coinbase.com'
-        options[:base_uri] = 'https://api.sandbox.coinbase.com/v1'
       end
+
       site = options[:site] || OAUTH_SITE
       client_opts = {
         :site          => options[:base_uri] || BASE_URI,

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -259,6 +259,18 @@ describe Coinbase::Client do
     r.success.should == true
   end
 
+  # Orders
+
+  it "should show an order" do
+    id = "A7C52JQT"
+    status = "completed"
+    fake :get, "/orders/#{id}/", JSON.parse(File.read(File.dirname(__FILE__) + '/fixtures/example_order.json'))
+
+    r = @c.order(id)
+    r.order.id.should == id
+    r.order.status.should == status
+  end
+
   # Users
 
   it "should let you get the current user details" do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -5,9 +5,16 @@ require 'coinbase'
 describe Coinbase::Client do
   BASE_URI = 'http://fake.com/api/v1' # switching to http (instead of https) seems to help FakeWeb
 
-  before :all do
+  before :each do
     @c = Coinbase::Client.new 'api key', 'api secret', {base_uri: BASE_URI}
     FakeWeb.allow_net_connect = false
+  end
+
+  # Sandbox
+
+  it "sets sandbox properly" do
+    c = Coinbase::Client.new 'api key', 'api secret', {sandbox: true}
+    c.instance_variable_get(:@base_uri).should == Coinbase::Client::SANDBOX_BASE_URI
   end
 
   # Auth and Errors

--- a/spec/fixtures/example_order.json
+++ b/spec/fixtures/example_order.json
@@ -1,0 +1,27 @@
+{ "order": {
+  "id": "A7C52JQT",
+  "created_at": "2013-03-11T22:04:37-07:00",
+  "status": "completed",
+  "total_btc": {
+    "cents": 10000000,
+    "currency_iso": "BTC"
+  },
+  "total_native": {
+    "cents": 10000000,
+    "currency_iso": "BTC"
+  },
+  "custom": "custom123",
+  "receive_address": "mgrmKftH5CeuFBU3THLWuTNKaZoCGJU5jQ",
+  "button": {
+    "type": "buy_now",
+    "name": "test",
+    "description": "",
+    "id": "eec6d08e9e215195a471eae432a49fc7"
+  },
+  "transaction": {
+    "id": "513eb768f12a9cf27400000b",
+    "hash": "4cc5eec20cd692f3cdb7fc264a0e1d78b9a7e3d7b862dec1e39cf7e37ababc14",
+    "confirmations": 0
+  }
+}
+}


### PR DESCRIPTION
This PR: 
- Lets you fetch an order from the API (``Coinbase::Client#order`)
- Lets you set the sandbox in `Coinbase::Client` so the sandbox is available in both `Coinbase::OAuthClient` and `Coinbase::Client`.

There are specs.

I originally submitted this as a PR just for showing an order but I forgot to do this change into a separate branch :stuck_out_tongue: 