### PR TITLE
Allows address creation to accept a callback_url

### DIFF
--- a/lib/coinbase/wallet/models/account.rb
+++ b/lib/coinbase/wallet/models/account.rb
@@ -37,7 +37,7 @@ module Coinbase
       end
 
       def create_address(params = {})
-        @client.create_address(self['id']) do |data, resp|
+        @client.create_address(self['id'], params) do |data, resp|
           yield(data, resp) if block_given?
         end
       end


### PR DESCRIPTION
Params should be passed in so that a callback_url can be set on a newly created address.