### PR TITLE
Remove standard library bigdecimal dependency

### DIFF
--- a/coinbase.gemspec
+++ b/coinbase.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|gem|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "bigdecimal"
-
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "webmock"


### PR DESCRIPTION
This breaks in Rubinius w/ omniauth-coinbase. See https://github.com/rubinius/rubinius/issues/3503.

(Standard libraries do not need to be added as dependencies, just require'd.)