### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ client.currencies
 **List exchange rates**
 
 ```ruby
-client.exchange_rate
+client.exchange_rates
 ```
 
 **Buy price**


### PR DESCRIPTION
The API to get the exchange rates is not `exchange_rate`, but `exchange_rates`.