### PR TITLE
Add missing account.address_transactions method

### DIFF
--- a/lib/coinbase/wallet/models/account.rb
+++ b/lib/coinbase/wallet/models/account.rb
@@ -36,6 +36,12 @@ module Coinbase
         end
       end
 
+      def address_transactions(address_id, params = {})
+        @client.address_transactions(self['id'], address_id, params) do |data, resp|
+          yield(data, resp) if block_given?
+        end
+      end
+
       def create_address(params = {})
         @client.create_address(self['id'], params) do |data, resp|
           yield(data, resp) if block_given?

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -59,6 +59,12 @@ describe Coinbase::Wallet::Account do
     expect(@object.address("test")).to eq mock_item
   end
 
+  it "gets address transactions" do
+    stub_request(:get, /#{@object.resource_path}\/addresses\/test\/transactions/)
+      .to_return(body: { data: mock_collection }.to_json)
+    expect(@object.address_transactions("test")).to eq mock_collection
+  end
+
   it "creates address" do
     stub_request(:post, /#{@object.resource_path}\/addresses/)
       .to_return(body: { data: mock_item }.to_json)


### PR DESCRIPTION
In the documentation, we specify that instances of Coinbase::Wallet::Account
have the following method:

**List transactiona for address**

```ruby
account.address_transactions(address_id)
```

But we forgot to implement this method.