### PR TITLE
Fix Markdown header link syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ If the request is not successful, the gem will raise an error. We try to raise a
 
 This is not intended to provide complete documentation of the API. For more detail, please refer to the [official documentation](https://developers.coinbase.com/api/v2).
 
-###[Market Data](https://developers.coinbase.com/api/v2#data-api)
+### [Market Data](https://developers.coinbase.com/api/v2#data-api)
 
 **List supported native currencies**
 
@@ -256,7 +256,7 @@ client.spot_price(currency: 'BTC-EUR')
 client.time
 ```
 
-###[Users](https://developers.coinbase.com/api/v2#users)
+### [Users](https://developers.coinbase.com/api/v2#users)
 
 **Get authorization info**
 
@@ -282,7 +282,7 @@ client.current_user
 client.update_current_user(name: "New Name")
 ```
 
-###[Accounts](https://developers.coinbase.com/api/v2#accounts)
+### [Accounts](https://developers.coinbase.com/api/v2#accounts)
 
 **List all accounts**
 
@@ -326,7 +326,7 @@ account.update!(name: "New Account Name")
 account.delete!
 ```
 
-###[Addresses](https://developers.coinbase.com/api/v2#addresses)
+### [Addresses](https://developers.coinbase.com/api/v2#addresses)
 
 **List receive addresses for account**
 
@@ -352,7 +352,7 @@ account.address_transactions(address_id)
 account.create_address
 ```
 
-###[Transactions](https://developers.coinbase.com/api/v2#transactions)
+### [Transactions](https://developers.coinbase.com/api/v2#transactions)
 
 **List transactions**
 
@@ -402,7 +402,7 @@ account.cancel_request(request_id)
 account.complete_request(request_id)
 ```
 
-###[Buys](https://developers.coinbase.com/api/v2#buys)
+### [Buys](https://developers.coinbase.com/api/v2#buys)
 
 **List buys**
 
@@ -431,7 +431,7 @@ buy = account.buy(amount: "1", currency: "BTC", commit: false)
 account.commit_buy(buy.id)
 ```
 
-###[Sells](https://developers.coinbase.com/api/v2#sells)
+### [Sells](https://developers.coinbase.com/api/v2#sells)
 
 **List sells**
 
@@ -460,7 +460,7 @@ sell = account.sell(amount: "1", currency: "BTC", commit: false)
 account.commit_sell(sell.id)
 ```
 
-###[Deposit](https://developers.coinbase.com/api/v2#deposits)
+### [Deposit](https://developers.coinbase.com/api/v2#deposits)
 
 **List deposits**
 
@@ -489,7 +489,7 @@ deposit = account.deposit(amount: "1", currency: "BTC", commit: false)
 account.commit_deposit(deposit.id)
 ```
 
-###[Withdrawals](https://developers.coinbase.com/api/v2#withdrawals)
+### [Withdrawals](https://developers.coinbase.com/api/v2#withdrawals)
 
 **List withdrawals**
 
@@ -518,7 +518,7 @@ withdraw = account.withdraw(amount: "1", currency: "BTC", commit: false)
 account.commit_withdrawal(withdrawal.id)
 ```
 
-###[Payment Methods](https://developers.coinbase.com/api/v2#payment-methods)
+### [Payment Methods](https://developers.coinbase.com/api/v2#payment-methods)
 
 **List payment methods**
 
@@ -532,7 +532,7 @@ client.payment_methods
 client.payment_method(payment_method_id)
 ```
 
-###[Merchants](https://developers.coinbase.com/api/v2#merchants)
+### [Merchants](https://developers.coinbase.com/api/v2#merchants)
 
 #### Get merchant
 
@@ -546,7 +546,7 @@ client.merchant(merchant_id)
 client.verify_callback(request.raw_post, request.headers['CB-SIGNATURE']) # true/false
 ```
 
-###[Orders](https://developers.coinbase.com/api/v2#orders)
+### [Orders](https://developers.coinbase.com/api/v2#orders)
 
 #### List orders
 


### PR DESCRIPTION
GitHub won't render these as intended unless there's a space between the heading indicator and the start of the link.