### PR TITLE
Buy with total instead of amount

### DIFF
--- a/lib/coinbase/wallet/api_client.rb
+++ b/lib/coinbase/wallet/api_client.rb
@@ -355,7 +355,7 @@ module Coinbase
       end
 
       def buy(account_id, params = {})
-        raise APIError, "Missing parameter: 'amount' or 'total'" unless params.include? 'amount' or params.include? 'total'
+        raise APIError, "Missing parameter: 'amount' or 'total'" unless params.include? :amount or params.include? :total
 
         out = nil
         post("/v2/accounts/#{account_id}/buys", params) do |resp|

--- a/lib/coinbase/wallet/api_client.rb
+++ b/lib/coinbase/wallet/api_client.rb
@@ -355,8 +355,8 @@ module Coinbase
       end
 
       def buy(account_id, params = {})
-        if !(params.include? :amount || params.include? :total)
-          raise APIError, "Missing parameter: #{:amount} or #{:total}"
+        if !(params.include? 'amount' || params.include? 'total')
+          raise APIError, "Missing parameter: 'amount' or 'total'"
         end
 
         out = nil

--- a/lib/coinbase/wallet/api_client.rb
+++ b/lib/coinbase/wallet/api_client.rb
@@ -396,9 +396,7 @@ module Coinbase
       end
 
       def sell(account_id, params = {})
-        [ :amount ].each do |param|
-          raise APIError, "Missing parameter: #{param}" unless params.include? param
-        end
+        raise APIError, "Missing parameter: 'amount' or 'total'" unless params.include? :amount or params.include? :total
 
         out = nil
         post("/v2/accounts/#{account_id}/sells", params) do |resp|

--- a/lib/coinbase/wallet/api_client.rb
+++ b/lib/coinbase/wallet/api_client.rb
@@ -355,8 +355,8 @@ module Coinbase
       end
 
       def buy(account_id, params = {})
-        [ :amount ].each do |param|
-          raise APIError, "Missing parameter: #{param}" unless params.include? param
+        if !(params.include? :amount || params.include? :total)
+          raise APIError, "Missing parameter: #{:amount} or #{:total}"
         end
 
         out = nil

--- a/lib/coinbase/wallet/api_client.rb
+++ b/lib/coinbase/wallet/api_client.rb
@@ -355,9 +355,7 @@ module Coinbase
       end
 
       def buy(account_id, params = {})
-        if !(params.include? 'amount' || params.include? 'total')
-          raise APIError, "Missing parameter: 'amount' or 'total'"
-        end
+        raise APIError, "Missing parameter: 'amount' or 'total'" unless params.include? 'amount' or params.include? 'total'
 
         out = nil
         post("/v2/accounts/#{account_id}/buys", params) do |resp|


### PR DESCRIPTION
The [documentation for placing a buy](https://developers.coinbase.com/api/v2#place-buy-order) clearly states that you need to specify either amount or total.

The current check was too strict, and only allows to specify the amount