### PR TITLE
Convert Negative Amounts to BigDecimal

### DIFF
--- a/lib/coinbase/wallet/models/api_object.rb
+++ b/lib/coinbase/wallet/models/api_object.rb
@@ -28,7 +28,7 @@ module Coinbase
         elsif key =~ /_at$/ && (Time.iso8601(val) rescue nil)
           Time.parse(val)
         elsif key == "amount" && val =~ /^.{0,1}\s*[0-9,]*\.{0,1}[0-9]*$/
-          BigDecimal(val.gsub(/[^0-9\.]/, ''))
+          BigDecimal(val.gsub(/[^0-9\.-]/, ''))
         else
           val
         end

--- a/spec/models/api_object_spec.rb
+++ b/spec/models/api_object_spec.rb
@@ -45,6 +45,13 @@ describe Coinbase::Wallet::APIObject do
     expect(@object.created_at.class).to eq Time
   end
 
+  describe '#format' do
+    it 'should convert negative amounts to BigDecimal' do
+      ret = @object.format('amount', '-0.1234')
+      expect(ret).to eq BigDecimal('-0.1234')
+    end
+  end
+
   describe '#update' do
     it 'should update object' do
       @object.update({'id' => '1234'})


### PR DESCRIPTION
A `send` transaction type may have a negative amount. `APIObject.format` is stripping out the negative sign when converting to `BigDecimal`. This commit tries to correctly support negative amounts.

## To Reproduce

Print out the formatted value compared the hash value. The value on the left is positive if the value on the right is negative.
```ruby
client = Coinbase::Wallet::Client.new(api_key: '', api_secret: '')
client.accounts.each do |account|
  client.transactions(account.id, fetch_all: true).each do |transaction|
    if transaction.type == 'send'
      puts "#{transaction.amount.amount} : #{BigDecimal(transaction.amount['amount'])}"
    end
  end
end
```