### PR TITLE
Add default URI path to url of v2-api_client http requests

### DIFF
--- a/lib/coinbase/wallet/adapters/net_http.rb
+++ b/lib/coinbase/wallet/adapters/net_http.rb
@@ -7,11 +7,15 @@ module Coinbase
         @conn.use_ssl = true if base_uri.scheme == 'https'
         @conn.cert_store = self.class.whitelisted_certificates
         @conn.ssl_version = :TLSv1_2
+        @api_path = base_uri.path
       end
 
       private
 
       def http_verb(method, path, body = nil, headers = {})
+        if (path.include? "v2")
+          path = @api_path + path
+        end
         case method
         when 'GET' then req = Net::HTTP::Get.new(path)
         when 'PUT' then req = Net::HTTP::Put.new(path)


### PR DESCRIPTION
For e2e integration testing, we want to use the Coinbase::Wallet::Client and the Coinbase::Wallet::OAuthClient from the development url. We need to use the development environment to bypass 2FA for our automated tests.

But the paths in the api http requests sent by the api_client.rb didn't account for any additional pre-set path (e.g. "/api") in the api_url of Wallet::Client or Wallet::OAuthClient.

This diff adds any pre-set path (e.g. "/api") to the http request path if it was part of the api_url of the Wallet::Client or Wallet::OAuthClient.